### PR TITLE
Rename get() to a better name

### DIFF
--- a/framework.iml
+++ b/framework.iml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_9">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.projectlombok:lombok:1.18.10" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-java:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-api:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-chrome-driver:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-edge-driver:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-firefox-driver:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-ie-driver:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-opera-driver:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-remote-driver:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-safari-driver:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: org.seleniumhq.selenium:selenium-support:3.141.59" level="project" />
+    <orderEntry type="library" name="Maven: net.bytebuddy:byte-buddy:1.8.15" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-exec:1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:25.0-jre" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
+    <orderEntry type="library" name="Maven: org.checkerframework:checker-compat-qual:2.0.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.errorprone:error_prone_annotations:2.1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.google.j2objc:j2objc-annotations:1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp3:okhttp:3.11.0" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okio:okio:1.14.0" level="project" />
+    <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
+    <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" name="Maven: io.github.bonigarcia:webdrivermanager:3.8.1" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
+    <orderEntry type="library" name="Maven: commons-io:commons-io:2.6" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.8.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.6" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.10" level="project" />
+    <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Maven: org.rauschig:jarchivelib:1.0.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-compress:1.18" level="project" />
+    <orderEntry type="library" name="Maven: org.jsoup:jsoup:1.11.3" level="project" />
+    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:1.26" level="project" />
+    <orderEntry type="module-library">
+      <library name="Maven: com.saucelabs:sauce_bindings:1.0-SNAPSHOT">
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/sauce_bindings.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="library" name="Maven: com.github.javafaker:javafaker:1.0.2" level="project" />
+    <orderEntry type="library" name="Maven: org.yaml:snakeyaml:android:1.23" level="project" />
+    <orderEntry type="library" name="Maven: com.github.mifmif:generex:1.0.2" level="project" />
+    <orderEntry type="library" name="Maven: dk.brics.automaton:automaton:1.11-8" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.10.3" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.10.3" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.10.3" level="project" />
+  </component>
+</module>

--- a/src/main/java/com/saucelabs/framework/Browser.java
+++ b/src/main/java/com/saucelabs/framework/Browser.java
@@ -54,11 +54,11 @@ public class Browser {
     // Navigation
     //
 
-    public void get(String url) {
+    public void goTo(String url) {
         getDriver().navigate().to(url);
     }
 
-    public void get(URL url) {
+    public void goTo(URL url) {
         getDriver().navigate().to(url);
     }
 

--- a/src/main/java/com/saucelabs/framework/pages/PageObject.java
+++ b/src/main/java/com/saucelabs/framework/pages/PageObject.java
@@ -39,10 +39,10 @@ public abstract class PageObject {
     public void visit() {
         try {
             if (!required.url().isEmpty()) {
-                browser.get(required.url());
+                browser.goTo(required.url());
                 return;
             } else if (!required.path().isEmpty()) {
-                browser.get(this.getBaseURL() + required.path());
+                browser.goTo(this.getBaseURL() + required.path());
                 return;
             }
         } catch (NullPointerException ignored) {

--- a/src/test/java/com/saucelabs/framework/browser/BrowserInformationTest.java
+++ b/src/test/java/com/saucelabs/framework/browser/BrowserInformationTest.java
@@ -8,13 +8,13 @@ public class BrowserInformationTest extends BaseTest {
 
     @Test
     public void getCurrentUrl() {
-        browser.get("https://www.saucedemo.com/");
+        browser.goTo("https://www.saucedemo.com/");
         Assert.assertEquals("https://www.saucedemo.com/", browser.getCurrentUrl());
     }
 
     @Test
     public void getTitle() {
-        browser.get("https://www.saucedemo.com/");
+        browser.goTo("https://www.saucedemo.com/");
         Assert.assertEquals("Swag Labs", browser.getTitle());
     }
 

--- a/src/test/java/com/saucelabs/framework/browser/BrowserNavigationTest.java
+++ b/src/test/java/com/saucelabs/framework/browser/BrowserNavigationTest.java
@@ -9,14 +9,14 @@ public class BrowserNavigationTest extends BaseTest {
 
     @Test
     public void get() {
-        browser.get("https://www.saucedemo.com/");
+        browser.goTo("https://www.saucedemo.com/");
         Assert.assertEquals(browser.getCurrentUrl(), "https://www.saucedemo.com/");
     }
 
     @Test
     public void forward() {
-        browser.get("https://www.saucedemo.com/");
-        browser.get("https://www.google.com/");
+        browser.goTo("https://www.saucedemo.com/");
+        browser.goTo("https://www.google.com/");
         browser.back();
         browser.forward();
 
@@ -25,8 +25,8 @@ public class BrowserNavigationTest extends BaseTest {
 
     @Test
     public void back() {
-        browser.get("https://www.saucedemo.com/");
-        browser.get("https://www.google.com/");
+        browser.goTo("https://www.saucedemo.com/");
+        browser.goTo("https://www.google.com/");
         browser.back();
 
         Assert.assertEquals(browser.getCurrentUrl(), "https://www.saucedemo.com/");
@@ -34,7 +34,7 @@ public class BrowserNavigationTest extends BaseTest {
 
     @Test
     public void refresh() {
-        browser.get("https://www.saucedemo.com/");
+        browser.goTo("https://www.saucedemo.com/");
         browser.getDriver().findElement(By.className("btn_action")).click();
         browser.refresh();
 

--- a/src/test/java/com/saucelabs/framework/elements/ElementClickTest.java
+++ b/src/test/java/com/saucelabs/framework/elements/ElementClickTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.fail;
 public class ElementClickTest extends BaseTest {
     @Test
     public void clickElementExistsAndVisible() {
-        browser.get("http://watir.com/examples/non_control_elements.html");
+        browser.goTo("http://watir.com/examples/non_control_elements.html");
         Element element = browser.element(By.id("best_language"));
 
         element.click();
@@ -26,7 +26,7 @@ public class ElementClickTest extends BaseTest {
 
     @Test
     public void clickElementWhenStale() {
-        browser.get("http://watir.com/examples/non_control_elements.html");
+        browser.goTo("http://watir.com/examples/non_control_elements.html");
         Element element = browser.element(By.id("best_language"));
         element.doesExist();
 
@@ -42,7 +42,7 @@ public class ElementClickTest extends BaseTest {
 
     @Test()
     public void clickElementExistsAndEventuallyVisibleAfterWait() {
-        browser.get("http://watir.com/examples/wait.html");
+        browser.goTo("http://watir.com/examples/wait.html");
 
         Element element = browser.element(By.id("bar"));
 
@@ -59,7 +59,7 @@ public class ElementClickTest extends BaseTest {
 
     @Test()
     public void clickElementEventuallyExistsThenEventuallyVisibleAfterWaits() {
-        browser.get("http://watir.com/examples/wait.html");
+        browser.goTo("http://watir.com/examples/wait.html");
 
         Element element = browser.element(By.id("foobar"));
 
@@ -76,7 +76,7 @@ public class ElementClickTest extends BaseTest {
 
     @Test()
     public void clickElementPresentAndEventuallyEnabledAfterWait() {
-        browser.get("http://watir.com/examples/wait.html");
+        browser.goTo("http://watir.com/examples/wait.html");
 
         Element element = browser.element(By.id("btn"));
 
@@ -93,7 +93,7 @@ public class ElementClickTest extends BaseTest {
 
     @Test()
     public void clickErrorsWhenElementPresentAndNeverEnabledAfterWait() {
-        browser.get("http://watir.com/examples/wait.html");
+        browser.goTo("http://watir.com/examples/wait.html");
         Element element = browser.element(By.id("btn"));
 
         Instant start = Instant.now();
@@ -128,7 +128,7 @@ public class ElementClickTest extends BaseTest {
 
     @Test()
     public void clickErrorsWhenElementExistsButNeverVisibleAfterWait() {
-        browser.get("http://watir.com/examples/wait.html");
+        browser.goTo("http://watir.com/examples/wait.html");
         Element element = browser.element(By.id("bar"));
 
         Instant start = Instant.now();

--- a/src/test/java/com/saucelabs/framework/elements/ElementCollectionTest.java
+++ b/src/test/java/com/saucelabs/framework/elements/ElementCollectionTest.java
@@ -4,14 +4,13 @@ import com.saucelabs.framework.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
 public class ElementCollectionTest extends BaseTest {
     @Test
     public void toListLocatesElements() {
-        browser.get("http://watir.com/examples/collections.html");
+        browser.goTo("http://watir.com/examples/collections.html");
         Element element = new Element(browser, By.tagName("span"));
         element.doesExist();
 
@@ -24,7 +23,7 @@ public class ElementCollectionTest extends BaseTest {
 
     @Test
     public void toListElementRelocatesStale() {
-        browser.get("http://watir.com/examples/collections.html");
+        browser.goTo("http://watir.com/examples/collections.html");
         Element element = new Element(browser, By.tagName("span"));
         List<Element> elementList = element.toList();
 

--- a/src/test/java/com/saucelabs/framework/elements/ElementInformationTest.java
+++ b/src/test/java/com/saucelabs/framework/elements/ElementInformationTest.java
@@ -15,7 +15,7 @@ import static junit.framework.TestCase.fail;
 public class ElementInformationTest extends BaseTest {
     @Test
     public void getTextElementExistsAndVisible() {
-        browser.get("http://watir.com/examples/non_control_elements.html");
+        browser.goTo("http://watir.com/examples/non_control_elements.html");
         Element element = browser.element(By.id("footer"));
 
         Assert.assertEquals("This is a footer.", element.getText());
@@ -23,7 +23,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getTextElementWhenStale() {
-        browser.get("http://watir.com/examples/non_control_elements.html");
+        browser.goTo("http://watir.com/examples/non_control_elements.html");
         Element element = browser.element(By.id("footer"));
         element.doesExist();
         browser.refresh();
@@ -54,7 +54,7 @@ public class ElementInformationTest extends BaseTest {
     // TODO - need to update testing site to just add exists not exists & visible combo
     @Test()
     public void getTextElementEventuallyExistsAfterWait() {
-        browser.get("http://watir.com/examples/wait.html");
+        browser.goTo("http://watir.com/examples/wait.html");
         Element element = browser.element(By.id("foobar"));
 
         Instant start = Instant.now();
@@ -70,7 +70,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getTextIsEmptyWhenElementExistsAndNotVisibleWithoutWaiting() {
-        browser.get("http://watir.com/examples/wait.html");
+        browser.goTo("http://watir.com/examples/wait.html");
         Element element = browser.element(By.id("bar"));
 
         Instant start = Instant.now();
@@ -84,7 +84,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getAttribute() {
-        browser.get("http://watir.com/examples/data_attributes.html");
+        browser.goTo("http://watir.com/examples/data_attributes.html");
         Element element = browser.element(By.tagName("p"));
 
         Assert.assertEquals("ruby-library", element.getAttribute("data-type"));
@@ -92,7 +92,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getAttributeWhenStale() {
-        browser.get("http://watir.com/examples/data_attributes.html");
+        browser.goTo("http://watir.com/examples/data_attributes.html");
         Element element = browser.element(By.tagName("p"));
         element.doesExist();
         browser.refresh();
@@ -107,7 +107,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getAttributeNullWhenMissing() {
-        browser.get("http://watir.com/examples/data_attributes.html");
+        browser.goTo("http://watir.com/examples/data_attributes.html");
         Element element = browser.element(By.tagName("p"));
 
         Assert.assertNull(element.getAttribute("foo"));
@@ -115,7 +115,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getAttributeElementDisabled() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_species"));
 
         Assert.assertEquals("new_user_species", element.getAttribute("name"));
@@ -123,7 +123,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getAttributeElementHidden() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_interests_dolls"));
 
         Assert.assertEquals("new_user_interests", element.getAttribute("name"));
@@ -146,7 +146,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getValue() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_occupation"));
 
         Assert.assertEquals("Developer", element.getValue());
@@ -154,7 +154,7 @@ public class ElementInformationTest extends BaseTest {
 
     @Test
     public void getValueElementReadOnly() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_code"));
 
         Assert.assertEquals("HE2FF8", element.getValue());

--- a/src/test/java/com/saucelabs/framework/elements/ElementSendKeysTest.java
+++ b/src/test/java/com/saucelabs/framework/elements/ElementSendKeysTest.java
@@ -17,7 +17,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test
     public void clearElementTextField() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_occupation"));
 
         element.clear();
@@ -44,7 +44,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test()
     public void clearTextErrorsWhenElementNotTextField() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("messages"));
 
         Instant start = Instant.now();
@@ -62,7 +62,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test()
     public void clearErrorsWhenElementDisabledAfterWait() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_species"));
 
         Instant start = Instant.now();
@@ -80,7 +80,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test()
     public void clearErrorsWhenElementNotReadableAfterWait() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("good_luck"));
 
         Instant start = Instant.now();
@@ -115,7 +115,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test
     public void appendText() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_occupation"));
 
         element.appendText("s are boring");
@@ -142,7 +142,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test()
     public void appendTextErrorsWhenElementNotTextField() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("messages"));
 
         Instant start = Instant.now();
@@ -160,7 +160,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test()
     public void appendTextErrorsWhenElementDisabledAfterWait() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_species"));
 
         Instant start = Instant.now();
@@ -178,7 +178,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test()
     public void appendTextErrorsWhenElementReadOnlyTextField() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("good_luck"));
 
         Instant start = Instant.now();
@@ -213,7 +213,7 @@ public class ElementSendKeysTest extends BaseTest {
 
     @Test
     public void setText() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_occupation"));
 
         element.setText("Just This");

--- a/src/test/java/com/saucelabs/framework/elements/ElementStateTest.java
+++ b/src/test/java/com/saucelabs/framework/elements/ElementStateTest.java
@@ -14,7 +14,7 @@ import static junit.framework.TestCase.fail;
 public class ElementStateTest extends BaseTest {
     @Test
     public void elementExists() {
-        browser.get("https://www.saucedemo.com");
+        browser.goTo("https://www.saucedemo.com");
         Element element = browser.element(By.id("user-name"));
 
         Assert.assertTrue(element.doesExist());
@@ -35,7 +35,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementPresentWhenDisplayed() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_interests_dentistry"));
 
         Assert.assertTrue(element.isPresent());
@@ -43,7 +43,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementPresentWhenStale() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_interests_dentistry"));
         element.doesExist();
 
@@ -67,7 +67,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementNotPresentWhenExistsAndNotDisplayedWithoutWaiting() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_interests_dolls"));
 
         Instant start = Instant.now();
@@ -81,7 +81,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementEnabled() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_occupation"));
 
         Assert.assertTrue(element.isEnabled());
@@ -89,7 +89,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementEnabledWhenStale() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_occupation"));
         element.doesExist();
 
@@ -100,7 +100,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementNotEnabledWithoutWaiting() {
-        browser.get("http://watir.com/examples/forms_with_input_elements.html");
+        browser.goTo("http://watir.com/examples/forms_with_input_elements.html");
         Element element = browser.element(By.id("new_user_species"));
 
         Instant start = Instant.now();
@@ -129,7 +129,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementStale() {
-        browser.get("https://www.saucedemo.com");
+        browser.goTo("https://www.saucedemo.com");
         Element element = browser.element(By.id("user-name"));
         element.doesExist();
         browser.refresh();
@@ -139,7 +139,7 @@ public class ElementStateTest extends BaseTest {
 
     @Test
     public void elementNotStale() {
-        browser.get("https://www.saucedemo.com");
+        browser.goTo("https://www.saucedemo.com");
         Element element = browser.element(By.id("user-name"));
         element.doesExist();
 


### PR DESCRIPTION
Never been a fan of the `get()` method on the Java API. Can we rename that to something that makes more sense?